### PR TITLE
Add top level statuses that can be inferred from PPTS.

### DIFF
--- a/relational/process_schemaless.py
+++ b/relational/process_schemaless.py
@@ -53,7 +53,7 @@ TableConfig = namedtuple('TableConfig',
 config = [
     tabledef.ProjectFacts(),
     tabledef.ProjectUnitCountsFull(),
-    # TODO: ProjectStatusHistory
+    tabledef.ProjectStatusHistory(),
     tabledef.ProjectGeo(),
     tabledef.ProjectDetails(),
 ]

--- a/relational/table.py
+++ b/relational/table.py
@@ -271,7 +271,6 @@ class ProjectStatusHistory(Table):
     TOP_LEVEL_STATUS = 'top_level_status'
     START_DATE = 'start_date'
     END_DATE = 'end_date'
-    SEQUENTIAL = 'sequential'
     DATA_SOURCE = 'data_source'
 
     def __init__(self):

--- a/relational/table.py
+++ b/relational/table.py
@@ -3,6 +3,8 @@
 
 from abc import ABC
 from abc import abstractmethod
+from datetime import date
+from datetime import datetime
 
 import re
 
@@ -259,4 +261,155 @@ class ProjectDetails(NameValueTable):
         result = []
         self._square_feet(result, proj)
         self._bedroom_info(result, proj)
+        return result
+
+
+class ProjectStatusHistory(Table):
+    _PPTS_ENT_CODES = {'ENV', 'AHB', 'COA', 'CUA', 'CTZ', 'DNX', 'ENX',
+                       'OFA', 'PTA', 'SHD', 'TDM', 'VAR', 'WLS'}
+
+    TOP_LEVEL_STATUS = 'top_level_status'
+    START_DATE = 'start_date'
+    END_DATE = 'end_date'
+    SEQUENTIAL = 'sequential'
+    DATA_SOURCE = 'data_source'
+
+    def __init__(self):
+        super().__init__('project_status_history', header=[
+            self.TOP_LEVEL_STATUS,
+            self.START_DATE,
+            self.END_DATE,
+            self.DATA_SOURCE])
+
+    def _predevelopment_date(self, rows, proj):
+        # TODO: Use the PPA submitted date once we have pulled in the new
+        # PPTS data pipeline (if that doesn't exist fall back to using our
+        # own logic)
+        ppa_opened_field = proj.field(
+            'date_opened', PPTS.NAME,
+            entry_predicate=[('record_type_category',
+                              lambda x: x == 'PPA')])
+        if ppa_opened_field:
+            ppa_opened_date = datetime.strptime(
+                ppa_opened_field.split(' ')[0],
+                "%m/%d/%Y").date()
+            return (ppa_opened_date.strftime("%Y-%m-%d"), PPTS.OUTPUT_NAME)
+
+        return ('', None)
+
+    def _filed_for_entitlements_date(self, rows, proj):
+        # TODO: Use the Application Submitted date once we have pulled
+        # in the new PPTS data pipeline (if that doesn't exist fall back to
+        # our own logic)
+
+        # Look for the earliest date_opened on an ENT child of a PRJ.
+        root = proj.roots[PPTS.NAME][0]
+        if root.get_latest('record_type_category')[0] == 'PRJ':
+            oldest_open = date.max
+            for child in proj.children[PPTS.NAME]:
+                record_type = child.get_latest('record_type_category')[0]
+                if record_type not in self._PPTS_ENT_CODES:
+                    continue
+
+                date_opened_field = child.get_latest('date_opened')[0]
+                date_opened = datetime.strptime(
+                    date_opened_field.split(' ')[0],
+                    "%m/%d/%Y").date()
+                if date_opened < oldest_open:
+                    oldest_open = date_opened
+
+            if oldest_open < date.max:
+                return (oldest_open.strftime("%Y-%m-%d"), PPTS.OUTPUT_NAME)
+
+        return ('', None)
+
+    def _entitled_date(self, rows, proj):
+        # TODO: Use the Entitlements Approved date once we have pulled
+        # in the new PPTS data pipeline (if that doesn't exist fall back)
+
+        # Look for the ENT child of a PRJ with the latest date_closed
+        # (assuming all are closed). Fall back to the PRJ date.
+        root = proj.roots[PPTS.NAME][0]
+        if root.get_latest('record_type_category')[0] == 'PRJ':
+            newest_closed = date.min
+            count_closed_no_date = 0
+            for child in proj.children[PPTS.NAME]:
+                record_type = child.get_latest('record_type_category')[0]
+                if record_type not in self._PPTS_ENT_CODES:
+                    continue
+
+                date_closed_value = child.get_latest('date_closed')
+                status_value = child.get_latest('status')
+                if date_closed_value:
+                    date_closed = datetime.strptime(
+                        date_closed_value[0].split(' ')[0],
+                        "%m/%d/%Y").date()
+                    if date_closed > newest_closed:
+                        newest_closed = date_closed
+                elif status_value and 'closed' in status_value[0].lower():
+                    count_closed_no_date += 1
+                else:
+                    # ENT record is not closed, entitlements not approved
+                    return ('', None)
+
+            if newest_closed > date.min:
+                return (newest_closed.strftime("%Y-%m-%d"), PPTS.OUTPUT_NAME)
+            elif count_closed_no_date > 0:
+                # Fall back to PRJ date if all ENT child records are closed
+                # but there's no date
+                date_closed_field = root.get_latest('date_closed')[0]
+                if date_closed_field:
+                    date_closed = datetime.strptime(
+                        date_closed_field.split(' ')[0],
+                        "%m/%d/%Y").date()
+                    return (date_closed.strftime("%Y-%m-%d"), PPTS.OUTPUT_NAME)
+
+        return ('', None)
+
+    def status_row(self,
+                   proj,
+                   top_level_status='',
+                   start_date='',
+                   end_date='',
+                   data=''):
+        row = [''] * len(self.header())
+        self.gen_id(row, proj)
+        row[self.index(self.TOP_LEVEL_STATUS)] = top_level_status
+        row[self.index(self.START_DATE)] = start_date
+        row[self.index(self.END_DATE)] = end_date
+        row[self.index(self.DATA_SOURCE)] = data
+        return row
+
+    def rows(self, proj):
+        result = []
+        (predev_date, predev_data) = self._predevelopment_date(result, proj)
+        (filed_date, filed_data) = self._filed_for_entitlements_date(result,
+                                                                     proj)
+        (entitled_date, entitled_data) = self._entitled_date(result, proj)
+
+        if predev_date:
+            result.append(
+                self.status_row(proj,
+                                'pre-development',
+                                predev_date,
+                                filed_date,
+                                predev_data))
+
+        if filed_date:
+            result.append(
+                self.status_row(proj,
+                                'filed_for_entitlements',
+                                filed_date,
+                                entitled_date,
+                                filed_data))
+
+        # TODO Add the correct end dates once PTS statuses are added in
+        if entitled_date:
+            result.append(
+                self.status_row(proj,
+                                'entitled',
+                                entitled_date,
+                                '',
+                                entitled_data))
+
         return result

--- a/relational/test_table.py
+++ b/relational/test_table.py
@@ -9,6 +9,7 @@ from relational.project import NameValue
 from relational.project import Project
 from relational.table import ProjectDetails
 from relational.table import ProjectFacts
+from relational.table import ProjectStatusHistory
 from relational.table import ProjectUnitCountsFull
 from schemaless.create_uuid_map import Node
 from schemaless.create_uuid_map import RecordGraph
@@ -166,3 +167,227 @@ def test_project_details_bedroom_info(unit_graph):
     nvs = table.rows(proj_adu)
     assert _get_value_for_name(table, nvs, 'residential_units_adu_1br') == '1'
     assert _get_value_for_name(table, nvs, 'is_adu') == 'TRUE'
+
+
+StatusRow = namedtuple('StatusRow',
+                       ['top_level_status', 'start_date', 'end_date'])
+
+
+def _get_values_for_status(table, rows):
+    result = []
+    for row in rows:
+        top_level_status = row[table.index(table.TOP_LEVEL_STATUS)]
+        start_date = row[table.index(table.START_DATE)]
+        end_date = row[table.index(table.END_DATE)]
+        result.append(StatusRow(top_level_status, start_date, end_date))
+    return result
+
+
+@pytest.fixture
+def child_parent_graph():
+    rg = RecordGraph()
+    rg.add(Node(record_id='1'))
+    rg.add(Node(record_id='2', parents=['1']))
+    rg.add(Node(record_id='3', parents=['1']))
+    rg.add(Node(record_id='4', parents=['1']))
+    rg.add(Node(record_id='5'))
+    return rg
+
+
+def test_project_status_history_predevelopment(child_parent_graph):
+    d = datetime.fromisoformat('2019-01-01')
+    table = ProjectStatusHistory()
+
+    entries1 = [
+        Entry('1',
+              PPTS.NAME,
+              [NameValue('record_type_category', 'PRJ', d),
+               NameValue('date_opened', '11/18/2018 12:00:00 AM +0000', d)]),
+    ]
+    proj_no_ppa = Project('uuid1', entries1, child_parent_graph)
+    fields = table.rows(proj_no_ppa)
+    # No pre-development status if there is no PPA
+    status_rows = _get_values_for_status(table, fields)
+    assert len(status_rows) == 0
+
+    entries2 = [
+        Entry('1',
+              PPTS.NAME,
+              [NameValue('record_type_category', 'PRJ', d),
+               NameValue('date_opened', '11/18/2018 12:00:00 AM +0000', d)]),
+        Entry('2',
+              PPTS.NAME,
+              [NameValue('record_type_category', 'PPA', d),
+               NameValue('date_opened', '10/18/2018 12:00:00 AM +0000', d)]),
+        # ENT's don't matter for pre-development open date but do for end_date
+        Entry('3',
+              PPTS.NAME,
+              [NameValue('record_type_category', 'CUA', d),
+               NameValue('date_opened', '11/25/2018 12:00:00 AM +0000', d)])
+    ]
+
+    proj_with_ppa = Project('uuid1', entries2, child_parent_graph)
+    fields = table.rows(proj_with_ppa)
+    # Pre-development is taken from the PPA record date
+    status_rows = _get_values_for_status(table, fields)
+    assert len(status_rows) == 2
+    assert status_rows[0].top_level_status == 'pre-development'
+    assert status_rows[0].start_date == '2018-10-18'
+    assert status_rows[0].end_date == '2018-11-25'
+    # Filed status is taken from first open ENT record under PRJ
+    assert status_rows[1].top_level_status == 'filed_for_entitlements'
+    assert status_rows[1].start_date == '2018-11-25'
+    assert status_rows[1].end_date == ''
+
+
+def test_project_status_history_filed_for_entitlements(child_parent_graph):
+    d = datetime.fromisoformat('2019-01-01')
+    table = ProjectStatusHistory()
+
+    entries1 = [
+        Entry('1',
+              PPTS.NAME,
+              [NameValue('record_type_category', 'PRJ', d),
+               NameValue('date_opened', '11/18/2018 12:00:00 AM +0000', d)]),
+        Entry('2',
+              PPTS.NAME,
+              [NameValue('record_type_category', 'CUA', d),
+               NameValue('date_opened', '11/25/2018 12:00:00 AM +0000', d)]),
+        # Ignore any ENT records that don't have oldest open date
+        Entry('3',
+              PPTS.NAME,
+              [NameValue('record_type_category', 'ENV', d),
+               NameValue('date_opened', '11/28/2018 12:00:00 AM +0000', d)]),
+        # Ignore any non-ENT records
+        Entry('4',
+              PPTS.NAME,
+              [NameValue('record_type_category', 'ABC', d),
+               NameValue('date_opened', '11/30/2018 12:00:00 AM +0000', d)]),
+        # Ignore any record not part of the PRJ
+        Entry('5',
+              PPTS.NAME,
+              [NameValue('record_type_category', 'VAR', d),
+               NameValue('date_opened', '11/01/2018 12:00:00 AM +0000', d)]),
+    ]
+
+    proj = Project('uuid1', entries1, child_parent_graph)
+    fields = table.rows(proj)
+    status_rows = _get_values_for_status(table, fields)
+    # Filed status from earliest open ENT child record.
+    assert len(status_rows) == 1
+    assert status_rows[0].top_level_status == 'filed_for_entitlements'
+    assert status_rows[0].start_date == '2018-11-25'
+    assert status_rows[0].end_date == ''
+
+
+def test_project_status_history_entitled(child_parent_graph):
+    d = datetime.fromisoformat('2019-01-01')
+    table = ProjectStatusHistory()
+
+    entries1 = [
+        Entry('1',
+              PPTS.NAME,
+              [NameValue('record_type_category', 'PRJ', d),
+               NameValue('status', 'Accepted', d),
+               NameValue('date_opened', '11/18/2018 12:00:00 AM +0000', d)]),
+        # Ignore any ENT records that don't have newest closed date
+        Entry('2',
+              PPTS.NAME,
+              [NameValue('record_type_category', 'CUA', d),
+               NameValue('status', 'Closed - CEQA', d),
+               NameValue('date_opened', '11/25/2018 12:00:00 AM +0000', d),
+               NameValue('date_closed', '3/27/2019 12:00:00 AM +0000', d)]),
+        Entry('3',
+              PPTS.NAME,
+              [NameValue('record_type_category', 'VAR', d),
+               NameValue('status', 'Closed - XYZ', d),
+               NameValue('date_opened', '11/28/2018 12:00:00 AM +0000', d),
+               NameValue('date_closed', '4/15/2019 12:00:00 AM +0000', d)]),
+        # Ignore any non-ENT records
+        Entry('4',
+              PPTS.NAME,
+              [NameValue('record_type_category', 'ABC', d),
+               NameValue('status', 'closed', d),
+               NameValue('date_opened', '11/30/2018 12:00:00 AM +0000', d),
+               NameValue('date_closed', '5/20/2019 12:00:00 AM +0000', d)]),
+        # Ignore any record not part of the PRJ
+        Entry('5',
+              PPTS.NAME,
+              [NameValue('record_type_category', 'ENV', d),
+               NameValue('status', 'Closed', d),
+               NameValue('date_opened', '11/01/2018 12:00:00 AM +0000', d),
+               NameValue('date_closed', '5/28/2019 12:00:00 AM +0000', d)]),
+    ]
+
+    proj = Project('uuid1', entries1, child_parent_graph)
+    fields = table.rows(proj)
+    status_rows = _get_values_for_status(table, fields)
+    # Status looking at closed
+    assert len(status_rows) == 2
+    assert status_rows[0].top_level_status == 'filed_for_entitlements'
+    assert status_rows[0].start_date == '2018-11-25'
+    assert status_rows[0].end_date == '2019-04-15'
+    assert status_rows[1].top_level_status == 'entitled'
+    assert status_rows[1].start_date == '2019-04-15'
+    assert status_rows[1].end_date == ''
+
+    entries2 = [
+        Entry('1',
+              PPTS.NAME,
+              [NameValue('record_type_category', 'PRJ', d),
+               NameValue('status', 'Accepted', d),
+               NameValue('date_opened', '11/18/2018 12:00:00 AM +0000', d)]),
+        # ENT is still open, project is not entitlded
+        Entry('2',
+              PPTS.NAME,
+              [NameValue('record_type_category', 'CUA', d),
+               NameValue('status', 'Accepted', d),
+               NameValue('date_opened', '11/25/2018 12:00:00 AM +0000', d)]),
+        Entry('3',
+              PPTS.NAME,
+              [NameValue('record_type_category', 'VAR', d),
+               NameValue('status', 'Closed - XYZ', d),
+               NameValue('date_opened', '11/28/2018 12:00:00 AM +0000', d),
+               NameValue('date_closed', '4/15/2019 12:00:00 AM +0000', d)]),
+        Entry('4',
+              PPTS.NAME,
+              [NameValue('record_type_category', 'PPA', d),
+               NameValue('date_opened', '10/18/2018 12:00:00 AM +0000', d),
+               NameValue('date_closed', '1/1/2019 12:00:00 AM +0000', d)]),
+    ]
+
+    proj_not_entitled = Project('uuid1', entries2, child_parent_graph)
+    fields = table.rows(proj_not_entitled)
+    status_rows = _get_values_for_status(table, fields)
+    assert len(status_rows) == 2
+    assert status_rows[0].top_level_status == 'pre-development'
+    assert status_rows[0].start_date == '2018-10-18'
+    assert status_rows[0].end_date == '2018-11-25'
+    assert status_rows[1].top_level_status == 'filed_for_entitlements'
+    assert status_rows[1].start_date == '2018-11-25'
+    assert status_rows[1].end_date == ''
+
+    entries3 = [
+        Entry('1',
+              PPTS.NAME,
+              [NameValue('record_type_category', 'PRJ', d),
+               NameValue('status', 'Closed', d),
+               NameValue('date_opened', '11/18/2018 12:00:00 AM +0000', d),
+               NameValue('date_closed', '4/15/2019 12:00:00 AM +0000', d)]),
+        Entry('2',
+              PPTS.NAME,
+              [NameValue('record_type_category', 'VAR', d),
+               NameValue('status', 'Closed - XYZ', d),
+               NameValue('date_opened', '11/28/2018 12:00:00 AM +0000', d)]),
+    ]
+
+    proj_prj_closed = Project('uuid1', entries3, child_parent_graph)
+    fields = table.rows(proj_prj_closed)
+    status_rows = _get_values_for_status(table, fields)
+    assert len(status_rows) == 2
+    assert status_rows[0].top_level_status == 'filed_for_entitlements'
+    assert status_rows[0].start_date == '2018-11-28'
+    assert status_rows[0].end_date == '2019-04-15'
+    assert status_rows[1].top_level_status == 'entitled'
+    assert status_rows[1].start_date == '2019-04-15'
+    assert status_rows[1].end_date == ''


### PR DESCRIPTION
Start creating status history relational table data by creating top-level statuses related to PPTS data. This requires actually looking at the parent-child relationship when it comes to PPTS data. Even when we pull in new PPTS pipeline data we will probably have to still fall back to this logic.