### PR TITLE
Pull in TCO and Addenda Summary data into relational tables.

### DIFF
--- a/relational/process_schemaless.py
+++ b/relational/process_schemaless.py
@@ -18,8 +18,10 @@ from relational.project import Project
 from schemaless.create_uuid_map import RecordGraph
 from schemaless.sources import MOHCDInclusionary
 from schemaless.sources import MOHCDPipeline
+from schemaless.sources import PermitAddendaSummary
 from schemaless.sources import PPTS
 from schemaless.sources import PTS
+from schemaless.sources import TCO
 from schemaless.sources import source_map
 
 csv.field_size_limit(sys.maxsize)
@@ -71,6 +73,7 @@ class Freshness:
             'issued_date',
             'permit_creation_date',
         ]),
+        TCO.NAME: set(['date_issued']),
     }
 
     def __init__(self):
@@ -80,8 +83,10 @@ class Freshness:
         self._freshness_checks = {
             PPTS.NAME: self._ppts,
             PTS.NAME: self._pts,
+            TCO.NAME: self._tco,
             MOHCDPipeline.NAME: self._mohcd_pipeline,
             MOHCDInclusionary.NAME: self._mohcd_inclusionary,
+            PermitAddendaSummary.NAME: self._permit_addenda_summary,
         }
 
     def _check_and_log_good_date(self, date, source, line):
@@ -133,11 +138,17 @@ class Freshness:
     def _pts(self, line):
         self._extract_nv_date(line, PTS.NAME)
 
+    def _tco(self, line):
+        self._extract_nv_date(line, TCO.NAME)
+
     def _mohcd_pipeline(self, line):
         self._extract_last_updated(line, MOHCDPipeline.NAME)
 
     def _mohcd_inclusionary(self, line):
         self._extract_last_updated(line, MOHCDInclusionary.NAME)
+
+    def _permit_addenda_summary(self, line):
+        self._extract_last_updated(line, PermitAddendaSummary.NAME)
 
 
 # entries_map is a dict of key, value of string=>list of Entry, where key is

--- a/relational/table.py
+++ b/relational/table.py
@@ -183,16 +183,19 @@ def _get_tco_units(proj):
       from existing permits). None if no data in TCO.
     """
     num_tco_units = 0
-    tco_units_added = False
-    for root in proj.roots[TCO.NAME]:
-        num_tco_units += int(root.get_latest('num_units')[0])
-        tco_units_added = True
+    try:
+        fk_entries = proj.fields('num_units', TCO.NAME)
+        for (_, entries) in fk_entries.items():
+            # Add up all units, even if there are dupe foreign keys
+            for entry in entries:
+                entry_latest = entry.get_latest('num_units')
+                if entry_latest[0]:
+                    num_tco_units += int(entry_latest[0])
+    except ValueError:
+        num_tco_units = 0
+        pass
 
-    for child in proj.children[TCO.NAME]:
-        num_tco_units += int(child.get_latest('num_units')[0])
-        tco_units_added = True
-
-    return num_tco_units if tco_units_added else None
+    return num_tco_units if num_tco_units else None
 
 
 class ProjectFacts(Table):

--- a/relational/table.py
+++ b/relational/table.py
@@ -12,8 +12,10 @@ import re
 from schemaless.sources import AffordableRentalPortfolio
 from schemaless.sources import MOHCDInclusionary
 from schemaless.sources import MOHCDPipeline
+from schemaless.sources import PermitAddendaSummary
 from schemaless.sources import PPTS
 from schemaless.sources import PTS
+from schemaless.sources import TCO
 
 
 class Table(ABC):
@@ -172,6 +174,25 @@ def _get_dbi_units(proj):
         return dbi_prop - dbi_exist
 
     return None
+
+
+def _get_tco_units(proj):
+    """
+    Returns:
+      Net new units from TCO dataset (summation number of all unit numbers
+      from existing permits). None if no data in TCO.
+    """
+    num_tco_units = 0
+    tco_units_added = False
+    for root in proj.roots[TCO.NAME]:
+        num_tco_units += int(root.get_latest('num_units')[0])
+        tco_units_added = True
+
+    for child in proj.children[TCO.NAME]:
+        num_tco_units += int(child.get_latest('num_units')[0])
+        tco_units_added = True
+
+    return num_tco_units if tco_units_added else None
 
 
 class ProjectFacts(Table):
@@ -350,6 +371,13 @@ class ProjectUnitCountsFull(NameValueTable):
                                     name='net_num_units',
                                     value=str(dbi_net),
                                     data=PTS.OUTPUT_NAME))
+
+        tco_net = _get_tco_units(proj)
+        if tco_net is not None:
+            rows.append(self.nv_row(proj,
+                                    name='net_num_units',
+                                    value=str(tco_net),
+                                    data=TCO.OUTPUT_NAME))
 
         for source_override in [MOHCDPipeline.NAME, MOHCDInclusionary.NAME]:
             mohcd = _get_mohcd_units(proj, source_override=source_override)
@@ -544,6 +572,15 @@ class ProjectDetails(NameValueTable):
                                     value=sqft,
                                     data=PPTS.OUTPUT_NAME))
 
+    def _earliest_addenda_arrival(self, rows, proj):
+        date = proj.field('earliest_addenda_arrival',
+                          PermitAddendaSummary.NAME)
+        if date:
+            rows.append(self.nv_row(proj,
+                                    name='earliest_addenda_arrival',
+                                    value=date,
+                                    data=PermitAddendaSummary.OUTPUT_NAME))
+
     def rows(self, proj):
         result = []
         self._square_feet(result, proj)
@@ -551,6 +588,7 @@ class ProjectDetails(NameValueTable):
         self._bedroom_info_mohcd(result, proj)
         self._ami_info_mohcd(result, proj)
         self._is_100_affordable(result, proj)
+        self._earliest_addenda_arrival(result, proj)
         return result
 
 

--- a/relational/test_process_schemaless.py
+++ b/relational/test_process_schemaless.py
@@ -5,14 +5,18 @@ from collections import namedtuple
 from relational.process_schemaless import Freshness
 from relational.process_schemaless import is_seen_id
 from schemaless.sources import MOHCDPipeline
+from schemaless.sources import PermitAddendaSummary
 from schemaless.sources import PPTS
 from schemaless.sources import PTS
+from schemaless.sources import TCO
 
 
 def test_freshness():
     newer = datetime.fromisoformat('2020-01-01')
     pts = datetime.fromisoformat('2020-02-01')
+    tco = datetime.fromisoformat('2020-02-10')
     mohcd = datetime.fromisoformat('2019-01-01')
+    addenda = datetime.fromisoformat('2019-05-05')
 
     lines = []
     lines.append({
@@ -40,12 +44,27 @@ def test_freshness():
         'name': 'completed_date',
         'value': '02/01/2020',
     })
+    lines.append({
+        'source': TCO.NAME,
+        'name': 'date_issued',
+        'value': '02/05/2020',
+    })
+    lines.append({
+        'source': TCO.NAME,
+        'name': 'date_issued',
+        'value': '02/10/2020',
+    })
 
     # ignored because the field isn't permitted
     lines.append({
         'source': PTS.NAME,
         'name': 'arbitrary',
         'value': '02/02/2020',
+    })
+    lines.append({
+        'source': TCO.NAME,
+        'name': 'arbitrary',
+        'value': '05/02/2020',
     })
 
     # ignored, in the future
@@ -70,13 +89,23 @@ def test_freshness():
         'value': '01/01/2020',
     })
 
+    # permit addenda summary extracts from last_updated
+    lines.append({
+        'last_updated': '2019-05-05',  # isoformat for last_updated
+        'source': PermitAddendaSummary.NAME,
+        'name': 'earliest_addenda_arrival',
+        'value': '04/01/2015',
+    })
+
     fresh = Freshness()
     for line in lines:
         fresh.update_freshness(line)
 
     assert fresh.freshness[PPTS.NAME] == newer
     assert fresh.freshness[PTS.NAME] == pts
+    assert fresh.freshness[TCO.NAME] == tco
     assert fresh.freshness[MOHCDPipeline.NAME] == mohcd
+    assert fresh.freshness[PermitAddendaSummary.NAME] == addenda
     assert 'bamboozle' not in fresh.freshness
 
 

--- a/schemaless/sources.py
+++ b/schemaless/sources.py
@@ -327,6 +327,7 @@ class PTS(DirectSource):
 
 class TCO(DirectSource):
     NAME = 'tco'
+    OUTPUT_NAME = NAME
     DATE = Date('date_issued', '%Y/%m/%d')
     FK = PrimaryKey(NAME, 'building_permit_number', DATE)
     FIELDS = {
@@ -554,6 +555,7 @@ class PermitAddendaSummary(Source):
     those key fields.
     '''
     NAME = 'permit_addenda_summary'
+    OUTPUT_NAME = NAME
     FK = PrimaryKey(NAME, 'permit_number')
 
     FIELDS = [


### PR DESCRIPTION
Pull in the TCO data and the Addenda Summary data into the relational tables. Use the TCO data to fill out the unit count table. Use Addenda Summary data to make an insertion in the project details table.

Closes #73 