### PR TITLE
When counting completed units ensure we count the net units

### DIFF
--- a/relational/table.py
+++ b/relational/table.py
@@ -633,14 +633,18 @@ class ProjectCompletedUnitCounts(Table):
             date_completed = datetime.strptime(
                 date_completed_field.split(' ')[0],
                 '%m/%d/%Y').date()
-            num_units_entry = child.get_latest('proposed_units')
-            if not num_units_entry:
+            num_units_prop_entry = child.get_latest('proposed_units')
+            if not num_units_prop_entry:
                 continue
 
-            num_units = num_units_entry[0]
+            num_units_exist = 0
+            num_units_exist_entry = child.get_latest('existing_units')
+            if num_units_exist_entry:
+                num_units_exist = int(num_units_exist_entry[0])
+            num_units = int(num_units_prop_entry[0]) - num_units_exist
             rows.append(
                 self.completed_unit_row(proj,
-                                        num_units,
+                                        str(num_units),
                                         date_completed.isoformat(),
                                         PTS.OUTPUT_NAME))
 

--- a/relational/test_table.py
+++ b/relational/test_table.py
@@ -718,7 +718,6 @@ def test_table_project_units_completed_count(basic_graph, d):
                NameValue('permit_number', 'xyz', d),
                NameValue('current_status', 'complete', d),
                NameValue('completed_date', '2/10/2018', d),
-               NameValue('existing_units', '0', d),
                NameValue('proposed_units', '2', d)]),
         Entry('4',  # Ignore permits that are not complete
               PTS.NAME,
@@ -734,7 +733,7 @@ def test_table_project_units_completed_count(basic_graph, d):
 
     # Use PTS data since there are valid records
     assert len(num_rows) == 2
-    assert num_rows[0].num_units_completed == '5'
+    assert num_rows[0].num_units_completed == '4'
     assert num_rows[0].date_completed == '2018-02-05'
     assert num_rows[0].data == 'dbi'
     assert num_rows[1].num_units_completed == '2'


### PR DESCRIPTION
The TCO data sets actually lists out net units so to be consistent when looking at PTS data we should be using the same metric