### PR TITLE
Remove workdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ export AIRFLOW_HOME=./.airflow
 airflow initdb
 
 # Set variables for our dag
-airflow variables --set WORKDIR "$(pwd)/airflow"
 airflow variables --set UPLOAD False  # Disable uploading to DataSF
 mkdir -p $(pwd)/airflow
 ```
@@ -209,12 +208,12 @@ have an internet connection, just run
 pipenv shell
 
 python3 -m schemaless.create_schemaless \
-  schemaless-one.csv
+  --out_file=schemaless-one.csv
 
 python3 -m schemaless.create_uuid_map \
   --likely_match_file=outputdata/likelies-one.csv \
-  schemaless-one.csv \
-  uuid-map-one.csv
+  --schemaless_file=schemaless-one.csv \
+  --out_file=uuid-map-one.csv
 ```
 
 The source datasets will be downloaded to your machine automatically.
@@ -231,13 +230,13 @@ pipenv shell
 
 python3 -m schemaless.create_schemaless \
   --diff True \  # The prior schemaless file will be automatically downloaded
-  schemaless-two.csv
+  --out_file=schemaless-two.csv
 
 python3 -m schemaless.create_uuid_map \
   --likely_match_file=likelies-one.csv \
   --uuid_map_file=uuid-map-one.csv \  # Use IDs generated last time
-  schemaless-two.csv \
-  uuid-map-two.csv
+  --schemaless_file=schemaless-two.csv \
+  --out_file=uuid-map-two.csv
 ```
 
 Running this immediately after creating the schemaless file for the first time
@@ -259,12 +258,12 @@ python3 -m schemaless.create_schemaless \
   --affordable_file data/mohcd/affordable-rental-portfolio-2019-09-06.csv \
   --oewd_permits_file data/oewd-permits-2020-03-03.csv \
   --the-date=2020-02-27 \
-  schemaless-one.csv
+  --out_file=schemaless-one.csv
 
 python3 -m schemaless.create_uuid_map \
   --likely_match_file=likelies-one.csv \
-  schemaless-one.csv \
-  uuid-map-one.csv
+  --schemaless_file=schemaless-one.csv \
+  --out_file=uuid-map-one.csv
 
 # Note --the-date=2020-03-04, and that we don't need to specify every data
 # source file
@@ -274,13 +273,13 @@ python3 -m schemaless.create_schemaless \
   --pts_file data/pts/2020-01-24-pts-after-2013.csv.xz \
   --the-date=2020-03-04 \
   --diff_file schemaless-one.csv \
-  schemaless-two.csv
+  --out_file=schemaless-two.csv
 
 python3 -m schemaless.create_uuid_map \
   --likely_match_file=likelies-two.csv \
   --uuid_map_file=uuid-map-one.csv \
-  schemaless-two.csv \
-  uuid-map-two.csv
+  --schemaless_file=schemaless-two.csv \
+  --out_file=uuid-map-two.csv
 ```
 
 **NOTE** This also produces the file `likelies-two.csv` which can be used to determine
@@ -293,8 +292,8 @@ visualization and analysis easier. You can produce these files by running:
 
 ```sh
 python3 -m relational.process_schemaless \
-  schemaless-two.csv \
-  uuid-map-two.csv
+  --schemaless_file=schemaless-two.csv \
+  --uuid_map_file=uuid-map-two.csv
 ```
 
 ### Downloading data

--- a/dag.py
+++ b/dag.py
@@ -55,7 +55,6 @@ task_create_relational = PythonOperator(
     task_id='create_relational',
     python_callable=process_schemaless.run,
     op_kwargs={
-        'out_prefix': '{{ var.value.WORKDIR }}/',
         'upload': '{{ var.value.UPLOAD }}',
     },
     dag=dag,

--- a/dag.py
+++ b/dag.py
@@ -46,8 +46,6 @@ task_create_uuid_map = PythonOperator(
     task_id='create_uuid_map',
     python_callable=create_uuid_map.run,
     op_kwargs={
-        'out_file': '{{ var.value.WORKDIR }}/uuid.csv',
-        'likely_match_file': '{{ var.value.WORKDIR }}/likely-matches.csv',
         'upload': '{{ var.value.UPLOAD }}',
     },
     dag=dag,

--- a/dag.py
+++ b/dag.py
@@ -36,7 +36,6 @@ task_create_schemaless = PythonOperator(
     task_id='create_schemaless',
     python_callable=create_schemaless.run,
     op_kwargs={
-        'out_file': '{{ var.value.WORKDIR }}/schemaless.csv',
         'upload': '{{ var.value.UPLOAD }}',
         'diff': True,
     },

--- a/gen-test-data.sh
+++ b/gen-test-data.sh
@@ -34,7 +34,7 @@ python3 -m schemaless.create_schemaless \
   --the-date=2020-01-29 \
   --parcel_data_file=data/assessor/2020-02-18-parcels.csv.xz \
   --diff False \
-  testdata/schemaless-one.csv
+  --out_file testdata/schemaless-one.csv
 # We read in the uuid-map file generated previously so our uuids are stable
 python3 -m schemaless.create_uuid_map \
   --no_download True \
@@ -49,7 +49,7 @@ python3 -m schemaless.create_schemaless \
   --diff_file testdata/schemaless-one.csv \
   --the-date=2020-01-29 \
   --parcel_data_file=data/assessor/2020-02-18-parcels.csv.xz \
-  testdata/schemaless-two.csv
+  --out_file testdata/schemaless-two.csv
 # We read in the uuid-map file generated previously so our uuids are stable
 python3 -m schemaless.create_uuid_map \
   --schemaless_file=testdata/schemaless-one.csv \

--- a/gen-test-data.sh
+++ b/gen-test-data.sh
@@ -42,7 +42,7 @@ python3 -m schemaless.create_uuid_map \
   --likely_match_file=testdata/likelies-one.csv \
   --uuid_map_file=testdata/uuid-map-one.csv \
   --parcel_data_file=data/assessor/2020-02-18-parcels.csv.xz \
-  testdata/uuid-map-one.csv
+  --out_file testdata/uuid-map-one.csv
 python3 -m schemaless.create_schemaless \
   --no_download True \
   --planning_file testdata/planning-two.csv \
@@ -57,6 +57,6 @@ python3 -m schemaless.create_uuid_map \
   --likely_match_file=testdata/likelies-two.csv \
   --uuid_map_file=testdata/uuid-map-two.csv \
   --parcel_data_file=data/assessor/2020-02-18-parcels.csv.xz \
-  testdata/uuid-map-two.csv
+  --out_file testdata/uuid-map-two.csv
   # Note: When adding new records, use uuid-map-one so new UUIDs are persisted
   # --uuid_map_file=testdata/uuid-map-one.csv

--- a/relational/test_process_schemaless.py
+++ b/relational/test_process_schemaless.py
@@ -157,7 +157,7 @@ def test_run(tmpdir):
     run(schemaless_file='testdata/schemaless-two.csv',
         uuid_map_file='testdata/uuid-map-two.csv',
         parcel_data_file='data/assessor/2020-02-18-parcels.csv.xz',
-        out_prefix=(str(tmpdir) + "/"))
+        out_prefix=tmpdir)
 
     freshness = tmpdir.join("data_freshness.csv")
     assert filecmp.cmp('testdata/relational/data_freshness.csv', freshness)

--- a/schemaless/create_schemaless.py
+++ b/schemaless/create_schemaless.py
@@ -121,7 +121,7 @@ def dump_and_diff(sources, outfile, schemaless_file, the_date=None):
                         ])
 
 
-def run(out_file,
+def run(out_file='',
         no_download=False,
         planning_file='',
         pts_file='',
@@ -140,6 +140,12 @@ def run(out_file,
     sources = []
     dl_sources = {}
     destdir = tempfile.mkdtemp()
+    if not out_file:
+        out_file = pathlib.Path(destdir) / 'schemaless.csv'
+        logger.info("Will write output to %s", out_file)
+        # Make sure our output dir exists
+        out_file.parent.mkdir(parents=True, exist_ok=True)
+
     client = None
     if not no_download:
         client = get_client()
@@ -196,9 +202,6 @@ def run(out_file,
 
     mapblklot_gen.init(parcel_data_file)
 
-    # Make sure our output dir exists
-    pathlib.Path(out_file).parent.mkdir(parents=True, exist_ok=True)
-
     if diff_file:
         dump_and_diff(sources, out_file, diff_file, the_date)
     else:
@@ -238,7 +241,8 @@ if __name__ == "__main__":
                         help='Permit Addenda file', default='')
     parser.add_argument('--oewd_permits_file', help='OEWD permits file',
                         default='')
-    parser.add_argument('out_file', help='output file for schemaless csv')
+    parser.add_argument('--out_file', default='',
+                        help='Output file for schemaless csv.')
 
     parser.add_argument('--diff', type=bool, default=False)
     parser.add_argument(
@@ -258,7 +262,7 @@ if __name__ == "__main__":
     if args.the_date:
         the_date = datetime.strptime(args.the_date, "%Y-%m-%d").date()
 
-    run(args.out_file,
+    run(out_file=args.out_file,
         no_download=args.no_download,
         planning_file=args.planning_file,
         pts_file=args.pts_file,


### PR DESCRIPTION
This removes `WORKDIR` from the airflow config. We won't need it in production, it was really only for local testing.